### PR TITLE
FIx `event` metric recording

### DIFF
--- a/pyformance/reporters/influx.py
+++ b/pyformance/reporters/influx.py
@@ -120,7 +120,7 @@ class InfluxReporter(Reporter):
             for event in metric_values.get("events", []):
                 values = InfluxReporter._stringify_values(event.values)
 
-                line = "%s%s %s %s" % (
+                line = "%s,%s %s %s" % (
                     table,
                     tags,
                     values,


### PR DESCRIPTION
Previously https://github.com/alpha-health-ai/pyformance/pull/1 fixed tagging for most metrics, but the line generated for `event` metrics is different. Adding the fix for that metric type as well.